### PR TITLE
Point VLS dependencies to evan's git repo instead of a path

### DIFF
--- a/broker/Cargo.toml
+++ b/broker/Cargo.toml
@@ -10,8 +10,8 @@ rumqttd = "0.11.0"
 pretty_env_logger = "0.4.0"
 confy = "0.4.0"
 tokio = { version = "1.4.0", features = ["rt", "rt-multi-thread", "macros"] }
-vls-protocol = { path = "../../validating-lightning-signer/vls-protocol" }
-vls-proxy = { path = "../../validating-lightning-signer/vls-proxy" }
+vls-protocol = { git = "https://gitlab.com/Evanfeenstra/validating-lightning-signer.git", branch = "feature/vls-std" }
+vls-proxy = { git = "https://gitlab.com/Evanfeenstra/validating-lightning-signer.git", branch = "feature/vls-std" }
 sphinx-key-parser = { path = "../parser" }
 secp256k1 = { version = "0.20", features = ["rand-std", "bitcoin_hashes"] }
 anyhow = {version = "1", features = ["backtrace"]}

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-vls-protocol = { path = "../../validating-lightning-signer/vls-protocol" }
+vls-protocol = { git = "https://gitlab.com/Evanfeenstra/validating-lightning-signer.git", branch = "feature/vls-std" }
 serde = { version = "1.0", default-features = false }
 serde_bolt = { version = "0.2", default-features = false }
 

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 sphinx-key-parser = { path = "../parser" }
-vls-protocol-signer = { path = "../../validating-lightning-signer/vls-protocol-signer", default-features = false, features = ["secp-lowmemory", "vls-std"] }
+vls-protocol-signer = { git = "https://gitlab.com/Evanfeenstra/validating-lightning-signer.git", branch = "feature/vls-std", default-features = false, features = ["secp-lowmemory", "vls-std"] }
 anyhow = {version = "1", features = ["backtrace"]}
 log = "0.4"
 

--- a/tester/Cargo.toml
+++ b/tester/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 [dependencies]
 sphinx-key-signer = { path = "../signer" }
 sphinx-key-parser = { path = "../parser" }
-vls-protocol = { path = "../../validating-lightning-signer/vls-protocol" }
-vls-protocol-signer = { path = "../../validating-lightning-signer/vls-protocol-signer", default-features = false, features = ["secp-lowmemory", "vls-std"] }
+vls-protocol = { git = "https://gitlab.com/Evanfeenstra/validating-lightning-signer.git", branch = "feature/vls-std" }
+vls-protocol-signer = { git = "https://gitlab.com/Evanfeenstra/validating-lightning-signer.git", branch = "feature/vls-std", default-features = false, features = ["secp-lowmemory", "vls-std"] }
 anyhow = {version = "1", features = ["backtrace"]}
 log = "0.4"
 rumqttc = "0.12.0"


### PR DESCRIPTION
Makes it much easier when setting up the broker using Devrandom and Ken's Makefile in the CLN integration repo. https://gitlab.com/lightning-signer/vls-hsmd