### PR TITLE
Add OTA updates support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 target
 Cargo.lock
 !sphinx-key/Cargo.lock
+!factory/Cargo.lock
 .DS_Store
 notes.md
 test-flash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 
 exclude = [
     "broker",
+    "factory",
     "persister",
     "sphinx-key",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [workspace]
 
 members = [
-    "signer",
     "parser",
+    "signer",
     "tester",
 ]
 
 exclude = [
-    "sphinx-key",
-    "persister",
     "broker",
+    "persister",
+    "sphinx-key",
 ]

--- a/factory/.cargo/config.toml
+++ b/factory/.cargo/config.toml
@@ -1,0 +1,34 @@
+[build]
+# Uncomment the relevant target for your chip here (ESP32, ESP32-S2, ESP32-S3 or ESP32-C3)
+#target = "xtensa-esp32-espidf"
+#target = "xtensa-esp32s2-espidf"
+#target = "xtensa-esp32s3-espidf"
+target = "riscv32imc-esp-espidf"
+
+[target.xtensa-esp32-espidf]
+linker = "ldproxy"
+
+[target.xtensa-esp32s2-espidf]
+linker = "ldproxy"
+
+[target.xtensa-esp32s3-espidf]
+linker = "ldproxy"
+
+[target.riscv32imc-esp-espidf]
+linker = "ldproxy"
+
+# Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
+# See also https://github.com/ivmarkov/embuild/issues/16
+rustflags = ["-C", "default-linker-libraries"]
+
+[unstable]
+
+build-std = ["std", "panic_abort"]
+build-std-features = ["panic_immediate_abort"] # Required for older ESP-IDF versions without a realpath implementation
+
+[env]
+# Note: these variables are not used when using pio builder
+# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF stable (v4.4)
+ESP_IDF_VERSION = { value = "release/v4.4" }
+# Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master (mainline)
+#ESP_IDF_VERSION = { value = "master" }

--- a/factory/Cargo.lock
+++ b/factory/Cargo.lock
@@ -18,28 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aead"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
-dependencies = [
- "crypto-common",
- "generic-array",
- "heapless",
-]
-
-[[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,17 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 dependencies = [
  "backtrace",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -125,22 +92,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
-name = "base-x"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
-
-[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
-
-[[package]]
-name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bindgen"
@@ -166,37 +121,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
-
-[[package]]
-name = "bitcoin"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb36de3b18ad25f396f9168302e36fb7e1e8923298ab3127da252d288d5af9d"
-dependencies = [
- "bech32",
- "bitcoin_hashes",
- "secp256k1",
- "serde",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitfield"
@@ -209,16 +137,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bolt-derive"
-version = "0.1.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer.git#0d894bcc8e140c62755ba65be14de4ba4b15fbf3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "bstr"
@@ -240,12 +158,6 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
-name = "bytes"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "camino"
@@ -310,56 +222,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chacha20"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fc89c7c5b9e7a02dfe45cd2367bae382f9ed31c61ca8debe5f827c420a2f08"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "chacha20poly1305"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
-dependencies = [
- "aead",
- "chacha20",
- "cipher",
- "poly1305",
- "zeroize",
-]
-
-[[package]]
-name = "chrono"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
-dependencies = [
- "num-integer",
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "chunked_transfer"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
-
-[[package]]
-name = "cipher"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
-dependencies = [
- "crypto-common",
- "inout",
- "zeroize",
-]
 
 [[package]]
 name = "clang-sys"
@@ -406,12 +272,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
-
-[[package]]
 name = "cortex-m"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,15 +281,6 @@ dependencies = [
  "bitfield",
  "embedded-hal 0.2.7",
  "volatile-register",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -499,16 +350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "cstr_core"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,18 +371,8 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core 0.13.4",
- "darling_macro 0.13.4",
-]
-
-[[package]]
-name = "darling"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
-dependencies = [
- "darling_core 0.14.1",
- "darling_macro 0.14.1",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -558,37 +389,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core 0.13.4",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
-dependencies = [
- "darling_core 0.14.1",
+ "darling_core",
  "quote",
  "syn",
 ]
@@ -612,12 +418,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "either"
@@ -736,7 +536,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea83a3fbdc1d999ccfbcbee717eab36f8edf2d71693a23ce0d7cca19e085304c"
 dependencies = [
- "darling 0.13.4",
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
@@ -836,12 +636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flate2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,17 +658,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fsdb"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5545f523480b87f7ef5ecff5da72c41235096b10956e4db3f4b0d961f836c768"
-dependencies = [
- "rmp-serde",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -943,16 +726,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,15 +783,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -1060,12 +824,6 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "humantime"
@@ -1114,16 +872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "generic-array",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1133,15 +882,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1185,57 +925,6 @@ checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if",
  "winapi",
-]
-
-[[package]]
-name = "lightning"
-version = "0.0.110"
-source = "git+https://github.com/lightningdevkit/rust-lightning.git?rev=ea5b62fff69847941434fb51562e302eb4e7ff4b#ea5b62fff69847941434fb51562e302eb4e7ff4b"
-dependencies = [
- "bitcoin",
-]
-
-[[package]]
-name = "lightning-invoice"
-version = "0.18.0"
-source = "git+https://github.com/lightningdevkit/rust-lightning.git?rev=ea5b62fff69847941434fb51562e302eb4e7ff4b#ea5b62fff69847941434fb51562e302eb4e7ff4b"
-dependencies = [
- "bech32",
- "bitcoin_hashes",
- "lightning",
- "num-traits",
- "secp256k1",
-]
-
-[[package]]
-name = "lightning-signer-core"
-version = "0.1.0-5"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer.git#0d894bcc8e140c62755ba65be14de4ba4b15fbf3"
-dependencies = [
- "anyhow",
- "bitcoin",
- "env_logger",
- "hashbrown 0.11.2",
- "itertools",
- "lightning",
- "lightning-invoice",
- "log",
- "scopeguard",
-]
-
-[[package]]
-name = "lightning-signer-server"
-version = "0.1.0-5"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer.git#0d894bcc8e140c62755ba65be14de4ba4b15fbf3"
-dependencies = [
- "anyhow",
- "async-trait",
- "hex",
- "lightning-signer-core",
- "log",
- "time 0.2.27",
- "tonic-build",
- "vls-persist",
 ]
 
 [[package]]
@@ -1288,12 +977,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,25 +1011,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "num_cpus"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,15 +1042,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,22 +1057,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
-
-[[package]]
-name = "paste"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "peeking_take_while"
@@ -1432,16 +1075,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
-name = "petgraph"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,17 +1085,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "poly1305"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
-dependencies = [
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -1482,71 +1104,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd7356a8122b6c4a24a82b278680c73357984ca2fc79a0f9fa6dea7dced7c58"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prost"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
-dependencies = [
- "bytes",
- "heck 0.3.3",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prost",
- "prost-types",
- "regex",
- "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
-dependencies = [
- "bytes",
- "prost",
 ]
 
 [[package]]
@@ -1708,28 +1271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmp"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
-dependencies = [
- "byteorder",
- "num-traits",
- "paste",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25786b0d276110195fa3d6f3f31299900cf71dfbd6c28450f3f58a0e7f7a347e"
-dependencies = [
- "byteorder",
- "rmp",
- "serde",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,27 +1350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7649a0b3ffb32636e60c7ce0d70511eda9c52c658cd0634e194d5a19943aeff"
-dependencies = [
- "bitcoin_hashes",
- "rand",
- "secp256k1-sys",
- "serde",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7058dc8eaf3f2810d7828680320acda0b25a288f6d288e19278e249bbf74226b"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1863,16 +1383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bolt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704720009634ab092146c0b01eb578ae8b9d88eef028398752965fd766eb38bd"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,60 +1405,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
-dependencies = [
- "base64",
- "chrono",
- "hex",
- "serde",
- "serde_json",
- "serde_with_macros",
- "time 0.3.14",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
-dependencies = [
- "darling 0.14.1",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
-]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
-
-[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,98 +1420,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "sphinx-auther"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33bd24149ede6f4ec091326eacf550cfa3fc00492d4e627a045c1bd690255362"
-dependencies = [
- "anyhow",
- "base64",
- "hex",
- "log",
- "secp256k1",
-]
-
-[[package]]
-name = "sphinx-crypter"
-version = "0.1.0"
-source = "git+https://github.com/stakwork/sphinx-rs.git#0c79f337a2abc76f10b2026be4260030a1a53db6"
-dependencies = [
- "anyhow",
- "chacha20poly1305",
- "rand",
- "secp256k1",
-]
-
-[[package]]
-name = "sphinx-glyph"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf0527b300544e9fe193611f1be1f76e3b25f5ceab4217347429c2912b60093e"
-dependencies = [
- "anyhow",
- "rmp-serde",
- "serde",
- "sphinx-auther",
-]
-
-[[package]]
-name = "sphinx-key"
+name = "sphinx-key-factory"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitflags",
- "embedded-hal 1.0.0-alpha.8",
+ "embedded-hal 0.2.7",
  "embedded-svc",
  "embuild 0.29.3",
  "esp-idf-hal",
  "esp-idf-svc",
  "esp-idf-sys",
- "hex",
- "log",
- "rmp-serde",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sphinx-crypter",
- "sphinx-key-signer",
- "url",
-]
-
-[[package]]
-name = "sphinx-key-parser"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "rmp-serde",
- "serde",
- "serde_bolt",
- "sphinx-auther",
- "sphinx-glyph",
- "vls-protocol",
-]
-
-[[package]]
-name = "sphinx-key-persister"
-version = "0.1.0"
-dependencies = [
- "fsdb",
- "hex",
- "lightning-signer-server",
- "log",
- "serde",
-]
-
-[[package]]
-name = "sphinx-key-signer"
-version = "0.1.0"
-dependencies = [
- "anyhow",
  "log",
  "rand",
- "sphinx-key-parser",
- "sphinx-key-persister",
- "vls-protocol-signer",
 ]
 
 [[package]]
@@ -2078,64 +1455,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "standback"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
-dependencies = [
- "version_check",
-]
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version 0.2.3",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
@@ -2186,12 +1505,6 @@ dependencies = [
  "rustversion",
  "syn",
 ]
-
-[[package]]
-name = "subtle"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -2263,54 +1576,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros",
- "version_check",
- "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
-dependencies = [
- "libc",
- "num_threads",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2333,24 +1598,6 @@ checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "tonic-build"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
-dependencies = [
- "proc-macro2",
- "prost-build",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "typenum"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "uncased"
@@ -2387,16 +1634,6 @@ name = "unicode-segmentation"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
-
-[[package]]
-name = "universal-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
-dependencies = [
- "crypto-common",
- "subtle",
-]
 
 [[package]]
 name = "untrusted"
@@ -2443,43 +1680,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "vls-persist"
-version = "0.1.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer.git#0d894bcc8e140c62755ba65be14de4ba4b15fbf3"
-dependencies = [
- "hex",
- "lightning-signer-core",
- "log",
- "serde",
- "serde_json",
- "serde_with",
-]
-
-[[package]]
-name = "vls-protocol"
-version = "0.1.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer.git#0d894bcc8e140c62755ba65be14de4ba4b15fbf3"
-dependencies = [
- "bolt-derive",
- "log",
- "serde",
- "serde_bolt",
- "serde_derive",
-]
-
-[[package]]
-name = "vls-protocol-signer"
-version = "0.1.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer.git#0d894bcc8e140c62755ba65be14de4ba4b15fbf3"
-dependencies = [
- "bit-vec",
- "lightning-signer-core",
- "log",
- "serde",
- "vls-protocol",
-]
 
 [[package]]
 name = "void"
@@ -2695,9 +1895,3 @@ name = "zero"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f1bc8a6b2005884962297587045002d8cfb8dcec9db332f4ca216ddc5de82c5"
-
-[[package]]
-name = "zeroize"
-version = "1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"

--- a/factory/Cargo.toml
+++ b/factory/Cargo.toml
@@ -24,3 +24,10 @@ anyhow = "1"
 
 [package.metadata.espflash]
 partition_table = "table.csv"
+
+[profile.release]
+strip = true  # Automatically strip symbols from the binary.
+opt-level = "z"  # Optimize for size.
+lto = true
+codegen-units = 1
+panic = "abort"

--- a/factory/Cargo.toml
+++ b/factory/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "sphinx-key-factory"
+version = "0.1.0"
+authors = ["decentclock <decentclock.5uh2k@slmail.me>"]
+edition = "2021"
+
+[features]
+pio = ["esp-idf-sys/pio"]
+
+[dependencies]
+esp-idf-sys = { version = "0.31.8", features = ["binstart"] }
+esp-idf-svc = { version = "0.42.3", features = ["experimental", "alloc"] }
+esp-idf-hal = "0.38.1"
+embedded-hal = "0.2.7"
+embedded-svc = "0.22.1"
+anyhow = { version = "1.0.65", features = ["backtrace"] }
+rand = "0.8.5"
+log = "0.4.17"
+bitflags = "1.3.2"
+
+[build-dependencies]
+embuild = "0.29"
+anyhow = "1"
+
+[package.metadata.espflash]
+partition_table = "table.csv"

--- a/factory/README.md
+++ b/factory/README.md
@@ -1,0 +1,14 @@
+# Sphinx Key Factory App
+
+The main function of this app is to write any `update.bin` files from the sd card to the flash of the ESP, and configure the ESP so that on the next boot, it boots the freshly written app.
+
+## Background Reading
+
+- Partition Tables: https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/partition-tables.html
+- Over-the-Air Updates: https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-reference/system/ota.html
+
+## Flashing factory and sphinx-key
+
+- First flash the factory app here using the usual `espflash` command, but add the `--partition-table` flag and point it to `table.csv` here. See `espflash -h` for more info.
+- Then use `esptool.py` to flash the sphinx-key binary at offset `0xc0000`.
+- Finally use this command to tell the ESP to boot the sphinx-key binary first ( there is no update to write to the ESP yet, so we don't boot the factory app ): `otatool.py switch_ota_partition --slot 0`

--- a/factory/build.rs
+++ b/factory/build.rs
@@ -1,0 +1,5 @@
+// Necessary because of this issue: https://github.com/rust-lang/cargo/issues/9641
+fn main() -> anyhow::Result<()> {
+    embuild::build::CfgArgs::output_propagated("ESP_IDF")?;
+    embuild::build::LinkArgs::output_propagated("ESP_IDF")
+}

--- a/factory/rust-toolchain.toml
+++ b/factory/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/factory/sdkconfig.defaults
+++ b/factory/sdkconfig.defaults
@@ -1,0 +1,11 @@
+# Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=64000
+# CONFIG_LOG_DEFAULT_LEVEL_DEBUG=y
+
+# Use this to set FreeRTOS kernel tick frequency to 1000 Hz (100 Hz by default).
+# This allows to use 1 ms granuality for thread sleeps (10 ms by default).
+#CONFIG_FREERTOS_HZ=1000
+
+# Workaround for https://github.com/espressif/esp-idf/issues/7631
+#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
+#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n

--- a/factory/src/led.rs
+++ b/factory/src/led.rs
@@ -1,0 +1,41 @@
+use embedded_hal::blocking::delay::DelayMs;
+use esp_idf_hal::delay::Ets;
+use esp_idf_hal::peripherals::Peripherals;
+use esp_idf_hal::rmt::config::TransmitConfig;
+use esp_idf_hal::rmt::{FixedLengthSignal, PinState, Pulse, Transmit};
+use std::time::Duration;
+
+pub fn set_ota_led() {
+    let peripherals = Peripherals::take().unwrap();
+    let led = peripherals.pins.gpio8.into_output().unwrap();
+    let channel = peripherals.rmt.channel0;
+    let config = TransmitConfig::new().clock_divider(1);
+    let mut tx = Transmit::new(led, channel, &config).unwrap();
+
+    let rgb = 0xffa500; // Orange
+
+    let ticks_hz = tx.counter_clock().unwrap();
+    let t0h = Pulse::new_with_duration(ticks_hz, PinState::High, &ns(350)).unwrap();
+    let t0l = Pulse::new_with_duration(ticks_hz, PinState::Low, &ns(800)).unwrap();
+    let t1h = Pulse::new_with_duration(ticks_hz, PinState::High, &ns(700)).unwrap();
+    let t1l = Pulse::new_with_duration(ticks_hz, PinState::Low, &ns(600)).unwrap();
+
+    let mut signal = FixedLengthSignal::<24>::new();
+    for i in 0..24 {
+        let bit = 2_u32.pow(i) & rotate_rgb(rgb) != 0;
+        let (high_pulse, low_pulse) = if bit { (t1h, t1l) } else { (t0h, t0l) };
+        signal.set(i as usize, &(high_pulse, low_pulse)).unwrap();
+    }
+    tx.start_blocking(&signal).unwrap();
+    Ets.delay_ms(10u8);
+}
+
+fn ns(nanos: u64) -> Duration {
+    Duration::from_nanos(nanos)
+}
+
+fn rotate_rgb(rgb: u32) -> u32 {
+    let b_mask: u32 = 0xff;
+    let blue = (rgb & b_mask) << 16;
+    blue | (rgb >> 8)
+}

--- a/factory/src/main.rs
+++ b/factory/src/main.rs
@@ -1,5 +1,7 @@
+mod led;
 mod ota;
 mod sdcard;
+use crate::led::set_ota_led;
 use esp_idf_sys as _; // If using the `binstart` feature of `esp-idf-sys`, always keep this module imported
 use log::{error, info, warn};
 use ota::{run_sdcard_ota_update, set_boot_main_app, UPDATE_BIN_PATH};
@@ -14,6 +16,7 @@ fn main() {
     esp_idf_sys::link_patches();
 
     thread::sleep(Duration::from_secs(10));
+    set_ota_led();
     info!("Hello, world! Mounting sd card...");
     sdcard::mount_sd_card();
     info!("SD card mounted! Checking for update...");

--- a/factory/src/main.rs
+++ b/factory/src/main.rs
@@ -1,0 +1,34 @@
+mod ota;
+mod sdcard;
+use esp_idf_sys as _; // If using the `binstart` feature of `esp-idf-sys`, always keep this module imported
+use log::{error, info, warn};
+use ota::{run_sdcard_ota_update, set_boot_main_app, UPDATE_BIN_PATH};
+use std::path::Path;
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+    // Temporary. Will disappear once ESP-IDF 4.4 is released, but for now it is necessary to call this function once,
+    // or else some patches to the runtime implemented by esp-idf-sys might not link properly.
+    esp_idf_svc::log::EspLogger::initialize_default();
+    esp_idf_sys::link_patches();
+
+    thread::sleep(Duration::from_secs(10));
+    info!("Hello, world! Mounting sd card...");
+    sdcard::mount_sd_card();
+    info!("SD card mounted! Checking for update...");
+    if let Ok(true) = Path::new(UPDATE_BIN_PATH).try_exists() {
+        info!("Found update.bin file! Launching the update process...");
+        while let Err(e) = run_sdcard_ota_update() {
+            error!("OTA update failed: {}", e.to_string());
+            error!("Trying again...");
+            thread::sleep(Duration::from_secs(5));
+        }
+        info!("OTA update complete!");
+    } else {
+        warn!("Update file not found! Setting up main app boot...");
+        set_boot_main_app();
+    }
+    info!("Restarting ESP, booting the main app...");
+    unsafe { esp_idf_sys::esp_restart() };
+}

--- a/factory/src/ota.rs
+++ b/factory/src/ota.rs
@@ -1,0 +1,51 @@
+use anyhow::Result;
+use embedded_svc::io::Write;
+use embedded_svc::ota::Ota;
+use embedded_svc::ota::OtaUpdate;
+use esp_idf_svc::ota::EspOta;
+use esp_idf_sys::{esp, esp_ota_get_next_update_partition, esp_ota_set_boot_partition};
+use log::info;
+use std::fs::File;
+use std::io::BufReader;
+use std::io::Read;
+use std::ptr;
+
+pub const UPDATE_BIN_PATH: &str = "/sdcard/update.bin";
+const BUFFER_LEN: usize = 1024;
+
+pub fn run_sdcard_ota_update() -> Result<()> {
+    let f = File::open(UPDATE_BIN_PATH)?;
+    let mut reader = BufReader::with_capacity(BUFFER_LEN, f);
+
+    let mut ota = EspOta::new()?;
+    let mut ota = ota.initiate_update()?;
+
+    let mut buf = [0_u8; BUFFER_LEN];
+    let mut read_tot: usize = 0;
+    let mut write_tot: usize = 0;
+    let mut i = 0;
+    loop {
+        let r = reader.read(&mut buf)?;
+        if r == 0 {
+            break;
+        }
+        let w = ota.write(&buf[..r])?;
+        read_tot += r;
+        write_tot += w;
+        i += 1;
+        if i % 20 == 0 {
+            info!("Cumulative bytes read: {}", read_tot);
+            info!("Cumulative bytes written: {}", write_tot);
+        }
+    }
+    info!("TOTAL read: {}", read_tot);
+    info!("TOTAL write: {}", write_tot);
+    ota.complete()?;
+    Ok(())
+}
+
+pub fn set_boot_main_app() {
+    let partition = unsafe { esp_ota_get_next_update_partition(ptr::null()) };
+    esp!(unsafe { esp_ota_set_boot_partition(partition) })
+        .expect("Couldn't set next boot partition...");
+}

--- a/factory/src/sdcard.rs
+++ b/factory/src/sdcard.rs
@@ -1,0 +1,138 @@
+use bitflags::bitflags;
+use esp_idf_sys::c_types::c_char;
+use esp_idf_sys::{
+    esp, esp_vfs_fat_sdmmc_mount_config_t, esp_vfs_fat_sdspi_mount, gpio_num_t, sdmmc_card_t,
+    sdmmc_host_t, sdspi_device_config_t, spi_bus_config_t, spi_bus_initialize, spi_host_device_t,
+    spi_host_device_t_SPI2_HOST,
+};
+use std::ptr;
+use std::thread;
+use std::time::Duration;
+
+const C_MOUNT_POINT: &'static [u8] = b"/sdcard\0";
+
+const SPI_HOST_SLOT: spi_host_device_t = spi_host_device_t_SPI2_HOST;
+const SPI_GPIO_MOSI: gpio_num_t = 7;
+const SPI_GPIO_CLK: gpio_num_t = 6;
+const SPI_GPIO_MISO: gpio_num_t = 2;
+const SPI_GPIO_CS: gpio_num_t = 10;
+
+bitflags! {
+    struct SDMMCHostFlag: u32 {
+        /// host supports 1-line SD and MMC protocol
+        const BIT1 = 1 << 0;
+        /// host supports 4-line SD and MMC protocol
+        const BIT4 = 1 << 1;
+        /// host supports 8-line MMC protocol
+        const BIT8 = 1 << 2;
+        /// host supports SPI protocol
+        const SPI = 1 << 3;
+        /// host supports DDR mode for SD/MMC
+        const DDR = 1 << 4;
+        /// host `deinit` function called with the slot argument
+        const DEINIT_ARG = 1 << 5;
+    }
+}
+
+#[allow(dead_code)]
+enum SDMMCFreq {
+    /// SD/MMC Default speed (limited by clock divider)
+    Default = 20000,
+    /// SD High speed (limited by clock divider)
+    HighSPeed = 40000,
+    /// SD/MMC probing speed
+    Probing = 400,
+    /// MMC 52MHz speed
+    _52M = 52000,
+    /// MMC 26MHz speed
+    _26M = 26000,
+}
+
+#[allow(unused)]
+pub fn mount_sd_card() {
+    while let Err(e) = setup() {
+        println!("Failed to mount sd card. Make sure it is connected, trying again...");
+        thread::sleep(Duration::from_secs(5));
+    }
+}
+
+fn setup() -> anyhow::Result<()> {
+    let mount_config = esp_vfs_fat_sdmmc_mount_config_t {
+        format_if_mount_failed: false,
+        max_files: 5,
+        allocation_unit_size: 16 * 1024,
+    };
+
+    let mut card: *mut sdmmc_card_t = ptr::null_mut();
+
+    let bus_cfg = spi_bus_config_t {
+        __bindgen_anon_1: esp_idf_sys::spi_bus_config_t__bindgen_ty_1 {
+            mosi_io_num: SPI_GPIO_MOSI,
+        },
+        __bindgen_anon_2: esp_idf_sys::spi_bus_config_t__bindgen_ty_2 {
+            miso_io_num: SPI_GPIO_MISO,
+        },
+        sclk_io_num: SPI_GPIO_CLK,
+        __bindgen_anon_3: esp_idf_sys::spi_bus_config_t__bindgen_ty_3 { quadwp_io_num: -1 },
+        __bindgen_anon_4: esp_idf_sys::spi_bus_config_t__bindgen_ty_4 { quadhd_io_num: -1 },
+        data4_io_num: -1,
+        data5_io_num: -1,
+        data6_io_num: -1,
+        data7_io_num: -1,
+        max_transfer_sz: 4000,
+        flags: 0,
+        intr_flags: 0,
+    };
+
+    if let Err(error) = esp!(unsafe {
+        spi_bus_initialize(
+            SPI_HOST_SLOT as u32,
+            &bus_cfg,
+            esp_idf_sys::spi_common_dma_t_SPI_DMA_CH_AUTO,
+        )
+    }) {
+        if error.code() != 259 {
+            return Err(anyhow::Error::new(error));
+        }
+    }
+
+    println!("Initialized SPI BUS!");
+
+    let slot_config = sdspi_device_config_t {
+        host_id: SPI_HOST_SLOT,
+        gpio_cs: SPI_GPIO_CS,
+        gpio_cd: -1,
+        gpio_wp: -1,
+        gpio_int: -1,
+    };
+
+    let host = sdmmc_host_t {
+        flags: (SDMMCHostFlag::SPI | SDMMCHostFlag::DEINIT_ARG).bits, //SDMMC_HOST_FLAG_SPI | SDMMC_HOST_FLAG_DEINIT_ARG,
+        slot: SPI_HOST_SLOT as i32,
+        max_freq_khz: SDMMCFreq::Default as i32, //SDMMC_FREQ_DEFAULT,
+        io_voltage: 3.3f32,
+        init: Some(esp_idf_sys::sdspi_host_init),
+        set_bus_width: None,
+        get_bus_width: None,
+        set_bus_ddr_mode: None,
+        set_card_clk: Some(esp_idf_sys::sdspi_host_set_card_clk),
+        do_transaction: Some(esp_idf_sys::sdspi_host_do_transaction),
+        __bindgen_anon_1: esp_idf_sys::sdmmc_host_t__bindgen_ty_1 {
+            deinit_p: Some(esp_idf_sys::sdspi_host_remove_device),
+        },
+        io_int_enable: Some(esp_idf_sys::sdspi_host_io_int_enable),
+        io_int_wait: Some(esp_idf_sys::sdspi_host_io_int_wait),
+        command_timeout_ms: 0,
+    };
+
+    esp!(unsafe {
+        esp_vfs_fat_sdspi_mount(
+            C_MOUNT_POINT.as_ptr() as *const c_char,
+            &host,
+            &slot_config,
+            &mount_config,
+            &mut card as *mut *mut sdmmc_card_t,
+        )
+    })?;
+    Ok(())
+}

--- a/factory/table.csv
+++ b/factory/table.csv
@@ -1,0 +1,7 @@
+# ESP-IDF Partition Table
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x4000,
+otadata,  data, ota,     0xd000,  0x2000,
+phy_init, data, phy,     0xf000,  0x1000,
+factory,  app,  factory, 0x10000, 1200K,
+ota_0,    app,  ota_0,   0x140000, 2800K,

--- a/factory/table.csv
+++ b/factory/table.csv
@@ -3,5 +3,5 @@
 nvs,      data, nvs,     0x9000,  0x4000,
 otadata,  data, ota,     0xd000,  0x2000,
 phy_init, data, phy,     0xf000,  0x1000,
-factory,  app,  factory, 0x10000, 377K,
-ota_0,    app,  ota_0,   0x70000, 3648K,
+factory,  app,  factory, 0x10000, 448K,
+ota_0,    app,  ota_0,   0x80000, 3584K,

--- a/factory/table.csv
+++ b/factory/table.csv
@@ -3,5 +3,5 @@
 nvs,      data, nvs,     0x9000,  0x4000,
 otadata,  data, ota,     0xd000,  0x2000,
 phy_init, data, phy,     0xf000,  0x1000,
-factory,  app,  factory, 0x10000, 1200K,
-ota_0,    app,  ota_0,   0x140000, 2800K,
+factory,  app,  factory, 0x10000, 377K,
+ota_0,    app,  ota_0,   0x70000, 3648K,

--- a/parser/src/control.rs
+++ b/parser/src/control.rs
@@ -2,7 +2,9 @@ use anyhow::Result;
 use sphinx_auther::nonce;
 use sphinx_auther::secp256k1::{PublicKey, SecretKey};
 use sphinx_auther::token::Token;
-pub use sphinx_glyph::types::{Config, ControlMessage, ControlResponse, Interval, Policy};
+pub use sphinx_glyph::types::{
+    Config, ControlMessage, ControlResponse, Interval, OtaParams, Policy,
+};
 use std::sync::{Arc, Mutex};
 
 // u64 is the nonce. Each signature must have a higher nonce

--- a/parser/src/control.rs
+++ b/parser/src/control.rs
@@ -106,7 +106,7 @@ impl Controller {
                 ControlResponse::AllowlistUpdated(na)
             }
             ControlMessage::Ota(params) => {
-                // ...
+                // same as above comments, actually done in core/events.rs
                 ControlResponse::OtaConfirm(params)
             }
         };

--- a/parser/src/control.rs
+++ b/parser/src/control.rs
@@ -56,7 +56,7 @@ impl Controller {
         Ok(rmp_serde::from_slice(input)?)
     }
     // return the OG message for further processing
-    pub fn handle(&mut self, input: &[u8]) -> anyhow::Result<(Vec<u8>, ControlMessage)> {
+    pub fn handle(&mut self, input: &[u8]) -> anyhow::Result<(ControlMessage, ControlResponse)> {
         let msg_nonce = self.parse_msg_no_nonce(input)?;
         let msg = msg_nonce.0;
         // nonce must be higher each time
@@ -110,8 +110,7 @@ impl Controller {
                 ControlResponse::OtaConfirm(params)
             }
         };
-        let response = self.build_response(res)?;
-        Ok((response, msg))
+        Ok((msg, res))
     }
 }
 

--- a/sphinx-key/Cargo.toml
+++ b/sphinx-key/Cargo.toml
@@ -25,7 +25,7 @@ esp-idf-sys = { version = "0.31.6", features = ["binstart"] }
 sphinx-key-signer = { path = "../signer", optional = true }
 sphinx-crypter = { git = "https://github.com/stakwork/sphinx-rs.git" }
 embedded-svc = "0.22.1"
-esp-idf-svc = "0.42.1"
+esp-idf-svc = { version = "0.42.1", features = ["experimental", "alloc"] }
 esp-idf-hal = "0.38.0"
 embedded-hal = "=1.0.0-alpha.8"
 anyhow = {version = "1", features = ["backtrace"]}

--- a/sphinx-key/sdkconfig.defaults
+++ b/sphinx-key/sdkconfig.defaults
@@ -1,6 +1,7 @@
 # Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=64000
-#CONFIG_LOG_DEFAULT_LEVEL_DEBUG=y
+CONFIG_PTHREAD_TASK_STACK_SIZE_DEFAULT=10000
+# CONFIG_LOG_DEFAULT_LEVEL_DEBUG=y
 
 # Use this to set FreeRTOS kernel tick frequency to 1000 Hz (100 Hz by default).
 # This allows to use 1 ms granuality for thread sleeps (10 ms by default).

--- a/sphinx-key/src/main.rs
+++ b/sphinx-key/src/main.rs
@@ -1,6 +1,7 @@
 #![feature(once_cell)]
 mod conn;
 mod core;
+mod ota;
 mod periph;
 
 use crate::core::control::{controller_from_seed, FlashPersister};

--- a/sphinx-key/src/ota.rs
+++ b/sphinx-key/src/ota.rs
@@ -1,0 +1,81 @@
+use anyhow::{anyhow, Result};
+use embedded_svc::http::client::Client;
+use embedded_svc::http::client::Request;
+use embedded_svc::http::client::Response;
+use embedded_svc::io::Read;
+use embedded_svc::ota::Ota;
+use esp_idf_svc::http::client::EspHttpClient;
+use esp_idf_svc::http::client::EspHttpClientConfiguration;
+use esp_idf_svc::http::client::FollowRedirectsPolicy::FollowNone;
+use esp_idf_svc::ota::EspOta;
+use log::{error, info};
+use std::fs::{remove_file, File};
+use std::io::BufWriter;
+use std::io::Write;
+
+const BUFFER_LEN: usize = 3072;
+const UPDATE_BIN_PATH: &str = "/sdcard/update.bin";
+
+fn factory_reset() -> Result<()> {
+    let mut ota = EspOta::new()?;
+    if ota.is_factory_reset_supported()? {
+        info!("Factory reset supported, attempting reset...");
+        ota.factory_reset()?;
+        Ok(())
+    } else {
+        error!("FACTORY RESET CURRENTLY NOT SUPPORTED!");
+        error!("Only wrote the update binary to the sdcard");
+        Err(anyhow!("Factory reset not supported"))
+    }
+}
+
+fn get_update(version: u64, mut url: String) -> Result<()> {
+    let configuration = EspHttpClientConfiguration {
+        buffer_size: Some(BUFFER_LEN),
+        buffer_size_tx: Some(BUFFER_LEN / 3),
+        follow_redirects_policy: FollowNone,
+        use_global_ca_store: true,
+        crt_bundle_attach: None,
+    };
+    let mut client = EspHttpClient::new(&configuration)?;
+    url.push_str(&version.to_string());
+    let mut response = client.get(&url)?.submit()?;
+    let mut reader = response.reader();
+
+    let _ = remove_file(UPDATE_BIN_PATH);
+    let file = File::create(UPDATE_BIN_PATH)?;
+    let mut writer = BufWriter::new(file);
+
+    let mut buf = [0_u8; BUFFER_LEN];
+    let mut read_tot: usize = 0;
+    let mut write_tot: usize = 0;
+    let mut i = 0;
+    loop {
+        let r = reader.read(&mut buf)?;
+        if r == 0 {
+            break;
+        }
+        let w = writer.write(&buf[..r])?;
+        read_tot += r;
+        write_tot += w;
+        i += 1;
+        if i % 20 == 0 {
+            info!("Cumulative bytes read: {}", read_tot);
+            info!("Cumulative bytes written: {}", write_tot);
+        }
+    }
+    info!("TOTAL read: {}", read_tot);
+    info!("TOTAL written: {}", write_tot);
+    Ok(())
+}
+
+pub fn update_sphinx_key(version: u64, url: String) -> Result<()> {
+    info!("Getting the update...");
+    info!("Version: {}", version.to_string());
+    info!("URL: {}", url);
+    get_update(version, url)?;
+    info!("Update written to sd card, performing factory reset");
+    factory_reset()?;
+    info!("Factory reset completed!");
+    Ok(())
+}

--- a/sphinx-key/src/periph/led.rs
+++ b/sphinx-key/src/periph/led.rs
@@ -19,15 +19,16 @@ pub struct Led {
 
 fn states() -> BTreeMap<Status, (Color, Time)> {
     let mut s = BTreeMap::new();
-    s.insert(Status::Starting, (0x000001, 100));
-    s.insert(Status::MountingSDCard, (0x000102, 100));
-    s.insert(Status::SyncingTime, (0x000122, 100));
-    s.insert(Status::WifiAccessPoint, (0x000100, 100));
-    s.insert(Status::Configuring, (0x010000, 20));
-    s.insert(Status::ConnectingToWifi, (0x010100, 350));
-    s.insert(Status::ConnectingToMqtt, (0x010001, 100));
-    s.insert(Status::Connected, (0x000101, 400));
-    s.insert(Status::Signing, (0x111111, 100));
+    s.insert(Status::Starting, (0x000001, 100)); // Blue
+    s.insert(Status::MountingSDCard, (0x000102, 100)); // Cyan
+    s.insert(Status::SyncingTime, (0x000122, 100)); // Cyan
+    s.insert(Status::WifiAccessPoint, (0x000100, 100)); // Green
+    s.insert(Status::Configuring, (0x010000, 20)); // Red
+    s.insert(Status::ConnectingToWifi, (0x010100, 350)); // Yellow
+    s.insert(Status::ConnectingToMqtt, (0x010001, 100)); // Purple
+    s.insert(Status::Connected, (0x000101, 400)); // Cyan
+    s.insert(Status::Signing, (0x111111, 100)); // White
+    s.insert(Status::Ota, (0xffa500, 100)); // Orange
     s
 }
 

--- a/tester/Cargo.toml
+++ b/tester/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 urlencoding = "2.1.0"
 dotenv = "0.15.0"
 rocket = "0.5.0-rc.2"
+rmp-serde = "1.1.0"
 
 [[bin]]
 name = "config"

--- a/tester/src/ctrl.rs
+++ b/tester/src/ctrl.rs
@@ -1,6 +1,6 @@
 use dotenv::dotenv;
 use serde::{Deserialize, Serialize};
-use sphinx_key_parser::control::{ControlMessage, Controller};
+use sphinx_key_parser::control::{ControlMessage, Controller, OtaParams};
 use sphinx_key_signer::lightning_signer::bitcoin::Network;
 use std::env;
 use std::time::Duration;
@@ -25,6 +25,15 @@ async fn main() -> anyhow::Result<()> {
     let seed = hex::decode(seed_string).expect("yo");
     let mut ctrl = controller_from_seed(&Network::Regtest, &seed, nonce);
 
+    let version_string: String = env::var("VERSION").unwrap_or("0".to_string());
+    let version: u64 = version_string.parse::<u64>().expect("failed to parse version");
+    let ota_url: String = env::var("OTA_URL").unwrap_or("http://192.168.1.10/sphinx-update-".to_string());
+    let control_message = ControlMessage::Ota(OtaParams {
+        version: version,
+        url: ota_url
+    });
+
+    //let msg = ctrl.build_msg(control_message)?;
     let msg = ctrl.build_msg(ControlMessage::Nonce)?;
     let msg_hex = hex::encode(&msg);
 

--- a/tester/src/main.rs
+++ b/tester/src/main.rs
@@ -101,13 +101,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 }
                                 topics::CONTROL => {
                                     match ctrlr.handle(&msg_bytes) {
-                                        Ok((response, _new_policy)) => {
+                                        Ok((_msg, res)) => {
+                                            let res_data = rmp_serde::to_vec(&res).expect("could not publish control response");
                                             client
                                                 .publish(
                                                     topics::CONTROL_RETURN,
                                                     QoS::AtMostOnce,
                                                     false,
-                                                    response,
+                                                    res_data,
                                                 )
                                                 .await
                                                 .expect("could not mqtt publish");
@@ -158,13 +159,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 }
                                 topics::CONTROL => {
                                     match ctrlr.handle(&msg_bytes) {
-                                        Ok((response, _new_policy)) => {
+                                        Ok((_msg, res)) => {
+                                            let res_data = rmp_serde::to_vec(&res).expect("could not publish control response");
                                             client
                                                 .publish(
                                                     topics::CONTROL_RETURN,
                                                     QoS::AtMostOnce,
                                                     false,
-                                                    response,
+                                                    res_data,
                                                 )
                                                 .await
                                                 .expect("could not mqtt publish");


### PR DESCRIPTION
- I add the `patcher` module, tasked with fetching updates from the HTTP server at the url specified in `ControlMessage::Ota` and writing the update to `/sdcard/update.bin`
- Then the `factory` app is there to grab this `update.bin` file and write it to the flash with the help of the ota functions in `esp-idf-svc`.
- Once this is done, the `factory` app sets up the ESP so that on next boot the newly written update is launched.
- I have not found a way to do a software restart without creating an `unsafe` block. The solution for now is to ask the user to press the reset button. I can definitely add this `unsafe` block with the automated software restart - let me know.
- Also note that this `patcher` module is only compiled when targeting the ESP. In the rest of the cases, I do nothing, and return a `ControlResponse::OtaConfirm(params)`. This is so that `parser` can still be used outside of the ESP.