### PR TITLE
Add http port setting

### DIFF
--- a/broker/src/main.rs
+++ b/broker/src/main.rs
@@ -98,7 +98,7 @@ async fn run_main(parent_fd: i32) -> rocket::Rocket<rocket::Build> {
     let (status_tx, mut status_rx) = mpsc::channel(1000);
     let (error_tx, _) = broadcast::channel(1000);
     log::info!("=> start broker on network: {}", settings.network);
-    start_broker(rx, status_tx, error_tx.clone(),CLIENT_ID, &settings).await;
+    start_broker(rx, status_tx, error_tx.clone(),CLIENT_ID, settings).await;
     log::info!("=> wait for connected status");
     // wait for connection = true
     let status = status_rx.recv().await.expect("couldnt receive");
@@ -124,7 +124,7 @@ async fn run_main(parent_fd: i32) -> rocket::Rocket<rocket::Build> {
     let mut signer_loop = SignerLoop::new(client, tx.clone());
     // spawn CLN listener on a std thread
     std::thread::spawn(move || {
-        signer_loop.start(Some(&settings));
+        signer_loop.start(Some(settings));
     });
 
     routes::launch_rocket(tx, error_tx)

--- a/broker/src/main.rs
+++ b/broker/src/main.rs
@@ -127,5 +127,5 @@ async fn run_main(parent_fd: i32) -> rocket::Rocket<rocket::Build> {
         signer_loop.start(Some(settings));
     });
 
-    routes::launch_rocket(tx, error_tx)
+    routes::launch_rocket(tx, error_tx, settings)
 }

--- a/broker/src/mqtt.rs
+++ b/broker/src/mqtt.rs
@@ -29,7 +29,7 @@ pub async fn start_broker(
     status_sender: mpsc::Sender<bool>,
     error_sender: broadcast::Sender<Vec<u8>>,
     expected_client_id: &str,
-    settings: &Settings,
+    settings: Settings,
 ) {
     let config = config(settings);
     let client_id = expected_client_id.to_string();
@@ -144,7 +144,7 @@ fn metrics_to_status(metrics: ConnectionMetrics, client_connected: bool) -> Opti
     }
 }
 
-fn config(settings: &Settings) -> Config {
+fn config(settings: Settings) -> Config {
     use librumqttd::rumqttlog::Config as RouterConfig;
     use librumqttd::{ConnectionSettings, SphinxLoginCredentials, ConsoleSettings, ServerSettings};
     use std::collections::HashMap;

--- a/broker/src/mqtt.rs
+++ b/broker/src/mqtt.rs
@@ -163,7 +163,7 @@ fn config(settings: Settings) -> Config {
         id.to_string(),
         ServerSettings {
             cert: None,
-            listen: SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), settings.port).into(),
+            listen: SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), settings.mqtt_port).into(),
             next_connection_delay_ms: 1,
             connections: ConnectionSettings {
                 connection_timeout_ms: 5000,

--- a/broker/src/run_test.rs
+++ b/broker/src/run_test.rs
@@ -50,7 +50,7 @@ pub async fn run_test() -> rocket::Rocket<rocket::Build> {
             };
         }
     });
-    launch_rocket(tx, error_tx)
+    launch_rocket(tx, error_tx, settings)
 }
 
 #[allow(dead_code)]

--- a/broker/src/run_test.rs
+++ b/broker/src/run_test.rs
@@ -21,7 +21,7 @@ pub async fn run_test() -> rocket::Rocket<rocket::Build> {
     let (tx, rx) = mpsc::channel(1000);
     let (status_tx, mut status_rx) = mpsc::channel(1000);
     let (error_tx, _) = broadcast::channel(1000);
-    start_broker(rx, status_tx, error_tx.clone(), CLIENT_ID, &settings).await;
+    start_broker(rx, status_tx, error_tx.clone(), CLIENT_ID, settings).await;
     let mut connected = false;
     let tx_ = tx.clone();
     tokio::spawn(async move {

--- a/broker/src/unix_fd.rs
+++ b/broker/src/unix_fd.rs
@@ -61,7 +61,7 @@ impl<C: 'static + Client> SignerLoop<C> {
     }
 
     /// Start the read loop
-    pub fn start(&mut self, settings: Option<&Settings>) {
+    pub fn start(&mut self, settings: Option<Settings>) {
         info!("loop {}: start", self.log_prefix);
         match self.do_loop(settings) {
             Ok(()) => info!("loop {}: done", self.log_prefix),
@@ -70,7 +70,7 @@ impl<C: 'static + Client> SignerLoop<C> {
         }
     }
 
-    fn do_loop(&mut self, settings: Option<&Settings>) -> Result<()> {
+    fn do_loop(&mut self, settings: Option<Settings>) -> Result<()> {
         loop {
             let raw_msg = self.client.read_raw()?;
             debug!("loop {}: got raw", self.log_prefix);

--- a/broker/src/util.rs
+++ b/broker/src/util.rs
@@ -7,15 +7,15 @@ use toml::Value;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Settings {
+    pub mqtt_port: u16,
     pub network: Network,
-    pub port: u16,
 }
 
 impl Default for Settings {
     fn default() -> Self {
         Settings {
+            mqtt_port: 1883,
             network: Network::Regtest,
-            port: 1883,
         }
     }
 }
@@ -28,8 +28,8 @@ pub fn read_broker_config(config_path: &str) -> Settings {
         if let Some(network) = read_network_setting(&table) {
             settings.network = network;
         }
-        if let Some(port) = read_port_setting(&table) {
-            settings.port = port;
+        if let Some(mqtt_port) = read_mqtt_port_setting(&table) {
+            settings.mqtt_port = mqtt_port;
         }
     } else {
         log::info!("File broker.conf not found, using default settings");
@@ -39,10 +39,10 @@ pub fn read_broker_config(config_path: &str) -> Settings {
             settings.network = net;
         }
     }
-    if let Ok(env_port) = env::var("BROKER_PORT") {
-        if let Ok(port) = env_port.parse::<u16>() {
-            if port > 1023 {
-                settings.port = port;
+    if let Ok(env_port) = env::var("BROKER_MQTT_PORT") {
+        if let Ok(mqtt_port) = env_port.parse::<u16>() {
+            if mqtt_port > 1023 {
+                settings.mqtt_port = mqtt_port;
             }
         }
     }
@@ -100,22 +100,22 @@ fn read_network_setting(table: &Value) -> Option<Network> {
     }
 }
 
-fn read_port_setting(table: &Value) -> Option<u16> {
-    if let None = table.get("port") {
-        log::info!("Broker port not specified, setting to default 1883");
+fn read_mqtt_port_setting(table: &Value) -> Option<u16> {
+    if let None = table.get("mqtt_port") {
+        log::info!("Broker mqtt port not specified, setting to default 1883");
         None
     } else {
-        let temp = table["port"]
+        let temp = table["mqtt_port"]
             .as_integer()
-            .expect("The port number is not an integer greater than 1023");
+            .expect("The mqtt port number is not an integer greater than 1023");
         if temp <= 1023 {
-            panic!("The port number is not an integer greater than 1023")
+            panic!("The mqtt port number is not an integer greater than 1023")
         }
         let max: i64 = u16::MAX.into();
         if temp > max {
-            panic!("The port number is way too big!")
+            panic!("The mqtt port number is way too big!")
         }
-        log::info!("Read broker port setting: {}", temp);
+        log::info!("Read broker mqtt port setting: {}", temp);
         Some(temp.try_into().unwrap())
     }
 }

--- a/broker/src/util.rs
+++ b/broker/src/util.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::str::FromStr;
 use toml::Value;
 
+#[derive(Clone, Copy, Debug)]
 pub struct Settings {
     pub network: Network,
     pub port: u16,

--- a/broker/src/util.rs
+++ b/broker/src/util.rs
@@ -7,6 +7,7 @@ use toml::Value;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Settings {
+    pub http_port: u16,
     pub mqtt_port: u16,
     pub network: Network,
 }
@@ -14,6 +15,7 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Settings {
+            http_port: 8000,
             mqtt_port: 1883,
             network: Network::Regtest,
         }
@@ -31,6 +33,9 @@ pub fn read_broker_config(config_path: &str) -> Settings {
         if let Some(mqtt_port) = read_mqtt_port_setting(&table) {
             settings.mqtt_port = mqtt_port;
         }
+        if let Some(http_port) = read_http_port_setting(&table) {
+            settings.http_port = http_port;
+        }
     } else {
         log::info!("File broker.conf not found, using default settings");
     }
@@ -43,6 +48,13 @@ pub fn read_broker_config(config_path: &str) -> Settings {
         if let Ok(mqtt_port) = env_port.parse::<u16>() {
             if mqtt_port > 1023 {
                 settings.mqtt_port = mqtt_port;
+            }
+        }
+    }
+    if let Ok(env_port) = env::var("BROKER_HTTP_PORT") {
+        if let Ok(http_port) = env_port.parse::<u16>() {
+            if http_port > 1023 {
+                settings.http_port = http_port;
             }
         }
     }
@@ -116,6 +128,26 @@ fn read_mqtt_port_setting(table: &Value) -> Option<u16> {
             panic!("The mqtt port number is way too big!")
         }
         log::info!("Read broker mqtt port setting: {}", temp);
+        Some(temp.try_into().unwrap())
+    }
+}
+
+fn read_http_port_setting(table: &Value) -> Option<u16> {
+    if let None = table.get("http_port") {
+        log::info!("Broker http port not specified, setting to default 8000");
+        None
+    } else {
+        let temp = table["http_port"]
+            .as_integer()
+            .expect("The http port number is not an integer greater than 1023");
+        if temp <= 1023 {
+            panic!("The http port number is not an integer greater than 1023")
+        }
+        let max: i64 = u16::MAX.into();
+        if temp > max {
+            panic!("The http port number is way too big!")
+        }
+        log::info!("Read broker http port setting: {}", temp);
         Some(temp.try_into().unwrap())
     }
 }


### PR DESCRIPTION
- This is mainly there to add `broker.conf` `http_port` setting and environment variable `BROKER_HTTP_PORT` both of which will set which port the rocket http server will listen on, with default set to `8000`.
- I set the rocket http server to listen on address `0.0.0.0` for ease of debugging everywhere.
- **I also change the `port` file setting to `mqtt_port` and `BROKER_PORT` to `BROKER_MQTT_PORT`.** See `broker/src/utils.rs`.