### PR TITLE
Custom stack size

### DIFF
--- a/sphinx-key/src/main.rs
+++ b/sphinx-key/src/main.rs
@@ -14,7 +14,8 @@ use crate::periph::sd::{mount_sd_card, simple_fs_test};
 use crate::status::Status;
 
 use anyhow::Result;
-use esp_idf_hal::gpio::Gpio9;
+use esp_idf_hal::gpio::{Gpio0, Gpio9};
+use esp_idf_hal::peripheral::Peripheral;
 use esp_idf_hal::peripherals::Peripherals;
 use esp_idf_svc::nvs::EspDefaultNvsPartition;
 use esp_idf_sys as _; // If using the `binstart` feature of `esp-idf-sys`, always keep this module imported
@@ -31,17 +32,21 @@ fn main() -> Result<()> {
     // Temporary. Will disappear once ESP-IDF 4.4 is released, but for now it is necessary to call this function once,
     // or else some patches to the runtime implemented by esp-idf-sys might not link properly.
     esp_idf_sys::link_patches();
-
     esp_idf_svc::log::EspLogger::initialize_default();
-
     thread::sleep(Duration::from_secs(1));
+    let mut peripherals = Peripherals::take().unwrap();
 
-    let peripherals = Peripherals::take().unwrap();
-    let pins = peripherals.pins;
-
-    let (led_tx, led_rx) = mpsc::channel();
     // LED control thread
-    led_control_loop(pins.gpio0, peripherals.rmt.channel0, led_rx);
+    let (mut led_tx, mut led_rx) = mpsc::channel::<Status>();
+    while let Err(e) = led_control_loop(
+        unsafe { Gpio0::new() },
+        unsafe { peripherals.rmt.channel0.clone_unchecked() },
+        led_rx,
+    ) {
+        log::error!("unable to spawn led thread: {:?}", e);
+        thread::sleep(Duration::from_millis(1000));
+        (led_tx, led_rx) = mpsc::channel::<Status>();
+    }
 
     led_tx.send(Status::MountingSDCard).unwrap();
     println!("About to mount the sdcard...");
@@ -57,9 +62,7 @@ fn main() -> Result<()> {
     let flash_per = FlashPersister::new(default_nvs.clone());
     let flash_arc = Arc::new(Mutex::new(flash_per));
     // BUTTON thread
-    while let Err(e) =
-        button_loop(unsafe { Gpio9::new() }, led_tx.clone(), flash_arc.clone())
-    {
+    while let Err(e) = button_loop(unsafe { Gpio9::new() }, led_tx.clone(), flash_arc.clone()) {
         log::error!("unable to spawn button thread: {:?}", e);
         thread::sleep(Duration::from_millis(1000));
     }

--- a/sphinx-key/src/main.rs
+++ b/sphinx-key/src/main.rs
@@ -14,17 +14,16 @@ use crate::periph::sd::{mount_sd_card, simple_fs_test};
 use crate::status::Status;
 
 use anyhow::Result;
+use esp_idf_hal::gpio::Gpio9;
+use esp_idf_hal::peripherals::Peripherals;
+use esp_idf_svc::nvs::EspDefaultNvsPartition;
 use esp_idf_sys as _; // If using the `binstart` feature of `esp-idf-sys`, always keep this module imported
+use sphinx_signer::lightning_signer::bitcoin::Network;
+use sphinx_signer::sphinx_glyph::control::{Config, ControlPersist, Policy, Velocity};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 use std::time::SystemTime;
-
-use esp_idf_hal::peripherals::Peripherals;
-use esp_idf_svc::nvs::EspDefaultNvsPartition;
-
-use sphinx_signer::lightning_signer::bitcoin::Network;
-use sphinx_signer::sphinx_glyph::control::{Config, ControlPersist, Policy, Velocity};
 
 const ID_LEN: usize = 12;
 
@@ -58,7 +57,12 @@ fn main() -> Result<()> {
     let flash_per = FlashPersister::new(default_nvs.clone());
     let flash_arc = Arc::new(Mutex::new(flash_per));
     // BUTTON thread
-    button_loop(pins.gpio9, led_tx.clone(), flash_arc.clone());
+    while let Err(e) =
+        button_loop(unsafe { Gpio9::new() }, led_tx.clone(), flash_arc.clone())
+    {
+        log::error!("unable to spawn button thread: {:?}", e);
+        thread::sleep(Duration::from_millis(1000));
+    }
     let flash = flash_arc.lock().unwrap();
     if let Ok(exist) = flash.read_config() {
         let seed = flash.read_seed().expect("no seed...");

--- a/sphinx-key/src/periph/button.rs
+++ b/sphinx-key/src/periph/button.rs
@@ -1,5 +1,6 @@
 use crate::status::Status;
 use crate::FlashPersister;
+use anyhow::Result;
 use esp_idf_hal::gpio;
 use esp_idf_hal::gpio::*;
 use sphinx_signer::sphinx_glyph::control::ControlPersist;
@@ -17,8 +18,9 @@ pub fn button_loop(
     gpio9: gpio::Gpio9,
     tx: mpsc::Sender<Status>,
     flash_arc: Arc<Mutex<FlashPersister>>,
-) {
-    thread::spawn(move || {
+) -> Result<()> {
+    let builder = thread::Builder::new().stack_size(2500);
+    builder.spawn(move || {
         let mut button = PinDriver::input(gpio9).unwrap();
         button.set_pull(Pull::Up).unwrap();
         let mut pressed = false;
@@ -116,7 +118,8 @@ pub fn button_loop(
                 }
             }
         }
-    });
+    })?;
+    Ok(())
 }
 
 struct Machine {


### PR DESCRIPTION
This customizes the stack sizes of both the LED and the button loops.

I would have expected a 16K increase in available DRAM, since we go from 10K stack size to 2.5K for button stack size, and to 1.5K for led stack size. But available DRAM only increases by 2K compared to master.

So this is a soft pull request. Happy to close if not worth it.

I also introduce three `unsafe` calls in `main.rs`, as these allow me to be able to loop on the attempt to spawn the thread while still passing ownership into the thread. I looked into avoiding these unsafe calls, but didn't find an immediate solution.

Happy to look into it further.